### PR TITLE
Expose helpers class in owncloud client

### DIFF
--- a/owncloud/owncloud.js
+++ b/owncloud/owncloud.js
@@ -53,6 +53,7 @@ function ownCloud(instance) {
 
     helpers.setInstance(set);
 
+    this.helpers = helpers;
     this.apps = new apps(helpers);
     this.shares = new shares(helpers);
     this.users = new users(helpers);


### PR DESCRIPTION
this allows access to helper functions like _makeOCSRequest - which is really handy.

We might even think to expose this fundtion and other helpers directly ....