### PR TITLE
Fix requests with body and set proper cors mode in fetch requests

### DIFF
--- a/src/owncloud.js
+++ b/src/owncloud.js
@@ -79,19 +79,24 @@ function ownCloud (instance, options = {}) {
         method: 'GET',
         service: helpers.OCS_SERVICE_CLOUD,
         action: 'user',
-        data: {}
+        data: null
       }
       options = Object.assign({}, defaults, options)
       const action = options.action.includes('?') ? options.action + '&format=json' : options.action + '?format=json'
       const url = helpers.instance + helpers.OCS_BASEPATH_V2 + options.service + '/' + action
-
-      return fetch(url, {
+      const init = {
         method: options.method,
+        mode: 'cors',
         headers: {
           authorization: helpers.getAuthorization(),
           'OCS-APIREQUEST': true
         }
-      })
+      }
+      if (options.data !== null) {
+        init.body = JSON.stringify(options.data)
+        init.headers['Content-Type'] = 'application/json'
+      }
+      return fetch(url, init)
     }
   }
 }

--- a/tests/requestsOcsTest.js
+++ b/tests/requestsOcsTest.js
@@ -45,13 +45,45 @@ describe('Main: Currently testing low level OCS', function () {
       method: 'PUT',
       service: 'cloud',
       action: 'users/unknown-user',
-      data: { 'display': 'Alice' }
+      data: { 'key': 'display', 'value': 'Alice' }
     }).then(response => {
       expect(response.ok).toBe(false)
       expect(response.status).toBe(401)
       return response.json()
     }).then(json => {
       expect(json.ocs.meta.statuscode).toBe(997)
+      done()
+    }).catch(error => {
+      fail(error)
+      done()
+    })
+  })
+
+  it('checking : PUT email', function (done) {
+    const testUser = 'testuer' + new Date().getTime()
+    oc.users.createUser(testUser, testUser).then(() => {
+      return oc.requests.ocs({
+        method: 'PUT',
+        service: 'cloud',
+        action: 'users/' + testUser,
+        data: { 'key': 'email', 'value': 'foo@bar.net' }
+      })
+    }).then(response => {
+      expect(response.ok).toBe(true)
+      expect(response.status).toBe(200)
+      return response.json()
+    }).then(json => {
+      expect(json.ocs.meta.statuscode).toBe(200)
+      return oc.requests.ocs({
+        service: 'cloud',
+        action: 'users/' + testUser
+      })
+    }).then(response => {
+      expect(response.ok).toBe(true)
+      expect(response.status).toBe(200)
+      return response.json()
+    }).then(json => {
+      expect(json.ocs.data.email).toBe('foo@bar.net')
       done()
     }).catch(error => {
       fail(error)


### PR DESCRIPTION
This allows to use a body in a oc.requests.ocs. Body as of is always content-type json 