### PR TITLE
No need to append a / at the end of the path before doing a propfind

### DIFF
--- a/src/fileManagement.js
+++ b/src/fileManagement.js
@@ -52,10 +52,6 @@ function Files (helperFile) {
  * @returns {Promise.<error>}         string: error message, if any.
  */
 Files.prototype.list = function (path, depth, properties) {
-  if (path[path.length - 1] !== '/') {
-    path += '/'
-  }
-
   if (typeof depth === 'undefined') {
     depth = 1
   }


### PR DESCRIPTION
A propfind for a file was sent to the path /remote.php/webdav/123.jpeg/

In some setups such a trailing slash will result in a 404